### PR TITLE
Error in example 1

### DIFF
--- a/examples/example-1-submitting-a-printjob.php
+++ b/examples/example-1-submitting-a-printjob.php
@@ -11,9 +11,8 @@ include 'credentials.php';
 // You first need to establish a connection to PrintNode. 
 // This can be done by using a PrintNode\ApiKey instance using your api-key.
 
-$credentials = new PrintNode\ApiKey(
-    PRINTNODE_APIKEY
-);
+$credentials = new PrintNode\Credentials();
+$credentials->setApiKey($config['PRINTNODE_APIKEY']);
 
 // Hint: Your API username is in the format description.integer, where description 
 // is the name given to the API key when you created it, followed by a dot (.) and an integer. 


### PR DESCRIPTION
Fixes the following error

```Fatal error: Uncaught TypeError: Argument 1 passed to PrintNode\Request::__construct() must be an instance of PrintNode\Credentials, instance of PrintNode\ApiKey given, called in my-file.php on line 13 and defined in vendor/printnode/printnode-php/src/PrintNode/Request.php:85

Stack trace:
#0 /var/www/vhosts/shakepack.co.uk/public/printnode.php(13): PrintNode\Request->__construct(Object(PrintNode\ApiKey))
#1 {main} thrown in /var/www/vhosts/shakepack.co.uk/vendor/printnode/printnode-php/src/PrintNode/Request.php on line 85```